### PR TITLE
Update Summit TVCG bibtex & Fix TOC CSS

### DIFF
--- a/public/bibliography.bib
+++ b/public/bibliography.bib
@@ -769,10 +769,11 @@ url={http://cognitivemedium.com/tat/index.html}
 @article{hohman2019summit,
   title={Summit: Scaling Deep Learning Interpretability by Visualizing Activation and Attribution Summarizations},
   author={Hohman, Fred and Park, Haekyu and Robinson, Caleb and Chau, Duen Horng Polo},
-  journal={IEEE transactions on visualization and computer graphics},
+  journal={IEEE Transactions on Visualization and Computer Graphics},
   volume={26},
   number={1},
   pages={1096--1106},
   year={2019},
-  publisher={IEEE}
+  publisher={IEEE},
+  url={https://arxiv.org/pdf/1904.02323.pdf}
 }

--- a/public/index.css
+++ b/public/index.css
@@ -260,6 +260,11 @@ h2 {
       font-weight: 600;
     }
 
+    d-contents nav>div>a:hover,
+    d-contents nav>ul>li>a:hover {
+        text-decoration: none;
+    }
+
 
 
 


### PR DESCRIPTION
I added the arXiv paper url to the Summit bibtex to display the `[PDF]` tag in the References section.

Edit: I've also added CSS code to remove the double underline in the TOC (assuming this wasn't by design).

Before:
<img width="374" alt="Screen Shot 2020-03-10 at 10 54 48 PM" src="https://user-images.githubusercontent.com/5741691/76377904-728b6f80-6322-11ea-9863-65707bc56d47.png">

After:
<img width="362" alt="Screen Shot 2020-03-10 at 10 56 34 PM" src="https://user-images.githubusercontent.com/5741691/76377911-75866000-6322-11ea-997b-f35deefa7f3a.png">
