### PR TITLE
Update links to use Weight Explorer now at gs://distill-circuits/

### DIFF
--- a/build.py
+++ b/build.py
@@ -39,7 +39,7 @@ for f in os.listdir("public/images/"):
       if "_" in neuron_id and neuron_id.split("_")[0] in layer_sizes:
         if neuron_id.count("_") > 1:
           neuron_id = neuron_id[:-2]
-        url = "https://storage.googleapis.com/inceptionv1-weight-explorer/%s.html" % neuron_id
+        url = "https://storage.googleapis.com/distill-circuits/inceptionv1-weight-explorer/%s.html" % neuron_id
         #pattern_n = line.split("#pattern")[1].split(")")[0]
         # print("link found!", neuron_id)
         text.append("<a href='%s'>" % url)


### PR DESCRIPTION
**This is PR 2 in a series of 3**. The others are:
* 1: https://github.com/distillpub/post--circuits-early-overview/pull/7
* 3: https://github.com/distillpub/post--circuits--frequency-edges/pull/14

Soon, Weight Explorer will no longer be at https://storage.googleapis.com/inceptionv1-weight-explorer as we are losing that cluster. We have migrated it to https://storage.googleapis.com/distill-circuits/inceptionv1-weight-explorer, at the new bucket gs://distill-circuits, instead.

This PR updates all relevant storage.googleapis.com links via a mass find-and-replace.